### PR TITLE
fix Windows path handling for client JS source file

### DIFF
--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -180,8 +180,13 @@ export class Server {
     if (!file.exists()) {
       throw new Error(`Cannot compile client file. "${this.#conf.clientJSSourceFile}" does not exist`);
     }
+    let clientJSSourceFile = this.#conf.clientJSSourceFile;
+    if (clientJSSourceFile.match(/^\/[A-Z]:/)) {
+      clientJSSourceFile = clientJSSourceFile.substring(1);
+    }
+
     return await Bun.build({
-      entrypoints: [this.#conf.clientJSSourceFile],
+      entrypoints: [clientJSSourceFile],
       outdir: this.#conf.clientJSDestDir,
     });
   }


### PR DESCRIPTION
fixes an issue where absolute Windows file paths starting with a drive letter (e.g., `C:\`) were not correctly handled when passing the client JS source file to `Bun.build()`